### PR TITLE
Release: 2.0.4-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahaui/css",
-  "version": "2.0.4-alpha.1",
+  "version": "2.0.4-alpha.2",
   "description": "Aha Design System - CSS",
   "style": "dist/index.min.css",
   "sass": "scss/index.scss",

--- a/scss/components/_bubbleChat.scss
+++ b/scss/components/_bubbleChat.scss
@@ -35,7 +35,7 @@
       &::after,
       #{$this}-typingContext::before,
       #{$this}-typingContext::after {
-        background: #fff;
+        background: #ffffff6e;
       }
     }
   }


### PR DESCRIPTION
- Change color of typing indicator of Bubble chat to `#ffffff6e`
![image](https://user-images.githubusercontent.com/20658926/106836257-67c09280-66cb-11eb-9720-1ab39e14d88c.png)
![image](https://user-images.githubusercontent.com/20658926/106836276-6f803700-66cb-11eb-9c0b-e6fa8be60d28.png)
