### PR TITLE
Fix checkbox position of Form.Check on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Release 2.0.5 - Unreleased
+### Fixed
+* SCSS:
+  - FormCheck-label: use `display: block` to prevent wrong position of `::before` pseudoelement, when it contains other `display: block` elements (Firefox bug).
+
 ## Release 2.0.4 - January 18, 2022
 ### Fixed
 * SCSS:

--- a/scss/components/_form.scss
+++ b/scss/components/_form.scss
@@ -9,6 +9,7 @@
 
   &-label {
     position: relative;
+    display: block;
 
     &::before,
     &::after {
@@ -17,7 +18,7 @@
       height: 1rem;
       left: -1.5rem;
       position: absolute;
-      top: 2px;
+      top: 4px;
       width: 1rem;
     }
 


### PR DESCRIPTION
- fix: Correct checkbox position when label contains block
- chore: Update CHANGELOG.md for release 2.0.5
